### PR TITLE
feat: Implement usage-based billing and pricing page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "next-themes": "^0.4.6",
         "prismjs": "^1.30.0",
         "random-word-slugs": "^0.1.7",
+        "rate-limiter-flexible": "^7.3.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.62.0",
@@ -1193,6 +1194,8 @@
     "random-word-slugs": ["random-word-slugs@0.1.7", "", {}, "sha512-8cyzxOIDeLFvwSPTgCItMXHGT5ZPkjhuFKUTww06Xg1dNMXuGxIKlARvS7upk6JXIm41ZKXmtlKR1iCRWklKmg=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, ""],
+
+    "rate-limiter-flexible": ["rate-limiter-flexible@7.3.2", "", {}, "sha512-lOnbiJAzlK5IGKPnCg8u5zJ+NQu3aCXZ+yCOG0p3tK/1Wjm0aqx9+pj0X1pV0ehipjmwVV1B0C9kW+xmfCkE3Q=="],
 
     "raw-body": ["raw-body@3.0.1", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.7.0", "unpipe": "1.0.0" } }, ""],
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "next-themes": "^0.4.6",
     "prismjs": "^1.30.0",
     "random-word-slugs": "^0.1.7",
+    "rate-limiter-flexible": "^7.3.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,3 +56,9 @@ model Project {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model Usage {
+  key    String    @id
+  points Int
+  expire DateTime?
+}

--- a/src/app/(home)/pricing/page.tsx
+++ b/src/app/(home)/pricing/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { PricingTable } from "@clerk/nextjs";
+import React from "react";
+import { dark } from "@clerk/themes";
+import { useCurrentTheme } from "@/hooks/use-current-theme";
+
+const Page = () => {
+  const currentTheme = useCurrentTheme();
+
+  return (
+    <div className="flex flex-col max-w-3xl mx-auto w-full">
+      <section className="space-y-6 pt-[16vh] 2xl:pt-48">
+        <div className="flex flex-col items-center">
+          {/* <Image src="" alt="Syntax Logo" width={50} height={50} className="hidden md:block"/>
+                TODO */}
+        </div>
+        <h1 className="text-xl md:text-3xl font-bold text-center">Pricing</h1>
+        <p className="text-muted-foreground text-center text-sm md:text-base">
+          Choose a plan that fits your needs.
+        </p>
+        <PricingTable
+          appearance={{
+            baseTheme: currentTheme === "dark" ? dark : undefined,
+            elements: {
+              pricingTableCard: "!border !shadow-none !rounded-lg",
+            },
+          }}
+          checkoutProps={{
+            appearance: {
+              baseTheme: currentTheme === "dark" ? dark : undefined,
+            },
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/hooks/use-scroll.tsx
+++ b/src/hooks/use-scroll.tsx
@@ -1,0 +1,18 @@
+import { useState, useEffect } from "react";
+
+export const useScroll = (threshold = 10) => {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > threshold);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll();
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [threshold]);
+
+  return isScrolled;
+};

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -1,0 +1,46 @@
+import { RateLimiterPrisma } from "rate-limiter-flexible";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@clerk/nextjs/server";
+
+const FREE_CREDITS = 50;
+const PRO_CREDITS = 100;
+const DURATION = 30 * 24 * 60 * 60;
+const GENERATION_COST = 1;
+export async function getUsageTracker() {
+  const { has } = await auth();
+  const hasProAccess = has({ plan: "pro_user" });
+
+  const usageTracker = new RateLimiterPrisma({
+    storeClient: prisma,
+    tableName: "Usage",
+    points: hasProAccess ? PRO_CREDITS + FREE_CREDITS : FREE_CREDITS,
+    duration: DURATION,
+  });
+
+  return usageTracker;
+}
+
+export async function consumeCredits() {
+  const { userId } = await auth();
+  if (!userId) throw new Error("User not authenticated");
+
+  const usageTracker = await getUsageTracker();
+  const result = await usageTracker.consume(userId, GENERATION_COST);
+
+  return result;
+}
+
+export async function resetUsage(userId: string) {
+  const usageTracker = await getUsageTracker();
+  await usageTracker.delete(userId);
+}
+
+export async function getUsageStatus() {
+  const { userId } = await auth();
+  if (!userId) throw new Error("User not authenticated");
+
+  const usageTracker = await getUsageTracker();
+  const result = usageTracker.get(userId);
+
+  return result;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ const isPublicRoute = createRouteMatcher([
   "/sign-in(.*)",
   "/sign-up(.*)",
   "/api(.*)",
+  "/pricing(.*)",
 ]);
 
 export default clerkMiddleware(async (auth, req) => {

--- a/src/modules/home/ui/components/navbar.tsx
+++ b/src/modules/home/ui/components/navbar.tsx
@@ -2,13 +2,22 @@
 
 import { Button } from "@/components/ui/button";
 import UserControl from "@/components/user-control";
+import { useScroll } from "@/hooks/use-scroll";
+import { cn } from "@/lib/utils";
 import { SignedOut, SignInButton, SignUpButton, SignedIn } from "@clerk/nextjs";
 import Link from "next/link";
 import React from "react";
 
 const Navbar = () => {
+  const isScrolled = useScroll();
+
   return (
-    <nav className="p-4 bg-transparent fixed top-0 left-0 right-0 z-50 transition-all duration-200 border-b border-transparent">
+    <nav
+      className={cn(
+        "p-4 bg-transparent fixed top-0 left-0 right-0 transition-all duration-200 border-b border-transparent",
+        isScrolled && "bg-background border-border"
+      )}
+    >
       <div className="max-w-5xl mx-auto w-full flex justify-between items-center">
         <Link href="/" className="flex items-center gap-2">
           {/* <Image src="" alt="Syntax Logo" width={24} height={24}/> */}

--- a/src/modules/home/ui/components/project-form.tsx
+++ b/src/modules/home/ui/components/project-form.tsx
@@ -52,8 +52,8 @@ const ProjectForm = () => {
     trpc.projects.create.mutationOptions({
       onSuccess: (data) => {
         queryClient.invalidateQueries(trpc.projects.getMany.queryOptions());
+        queryClient.invalidateQueries(trpc.usage.status.queryOptions());
         router.push(`/projects/${data.id}`);
-        // TODO: Revalidate usage status
       },
       onError: (error) => {
         toast.error(error.message);
@@ -68,7 +68,9 @@ const ProjectForm = () => {
           });
           return;
         }
-        // TODO: Redirect to pricing page if 402 or specific error
+        if (error.data?.code === "TOO_MANY_REQUESTS") {
+          router.push("/pricing");
+        }
       },
     })
   );

--- a/src/modules/projects/server/procedures.ts
+++ b/src/modules/projects/server/procedures.ts
@@ -4,6 +4,7 @@ import { protectedProcedure, createTRPCRouter } from "@/trpc/init";
 import { z } from "zod";
 import { generateSlug } from "random-word-slugs";
 import { TRPCError } from "@trpc/server";
+import { consumeCredits, getUsageStatus } from "@/lib/usage";
 export const projectsRouter = createTRPCRouter({
   getOne: protectedProcedure
     .input(
@@ -40,6 +41,46 @@ export const projectsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ input, ctx }) => {
+      try {
+        const result = await getUsageStatus();
+        if (!result) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Something went wrong",
+          });
+        }
+        if (result.remainingPoints < 1) {
+          throw new TRPCError({
+            code: "TOO_MANY_REQUESTS",
+            message: "You have run out of credits.",
+          });
+        }
+      } catch (error) {
+        if (error instanceof TRPCError) {
+          throw error;
+        }
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Something went wrong",
+        });
+      }
+      try {
+        await consumeCredits();
+      } catch (error) {
+        if (error instanceof Error) {
+          console.error(error);
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Something went wrong",
+          });
+        } else {
+          throw new TRPCError({
+            code: "TOO_MANY_REQUESTS",
+            message: "You have run out of credits.",
+          });
+        }
+      }
+
       const newProject = await prisma.project.create({
         data: {
           name: generateSlug(2, {

--- a/src/modules/projects/ui/components/usage.tsx
+++ b/src/modules/projects/ui/components/usage.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@clerk/nextjs";
+import { formatDuration, intervalToDuration } from "date-fns";
+import { CrownIcon } from "lucide-react";
+import Link from "next/link";
+import React from "react";
+
+interface usageProps {
+  credits: number;
+  msBeforeNext: number;
+}
+
+const Usage = ({ credits, msBeforeNext }: usageProps) => {
+  const { has } = useAuth();
+  const hasProAccess = has?.({ plan: "pro_user" });
+  return (
+    <div className="rounded-t-xl bg-background border border-b-0 p-2.5">
+      <div className="flex items-center gap-x-2">
+        <div>
+          <p className="text-sm">
+            {credits}
+            {hasProAccess ? "" : " free"} credits remaining
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Resets in{" "}
+            {formatDuration(
+              intervalToDuration({
+                start: new Date(),
+                end: new Date(Date.now() + msBeforeNext),
+              }),
+              { format: ["months", "days", "hours", "minutes"] }
+            )}
+          </p>
+        </div>
+        {!hasProAccess && (
+          <Button asChild size="sm" variant="default" className="ml-auto">
+            <Link href="/pricing">
+              <CrownIcon /> Upgrade
+            </Link>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Usage;

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import FileExplorer from "../components/file-explorer";
 import UserControl from "@/components/user-control";
+import { useAuth } from "@clerk/nextjs";
 interface ProjectViewProps {
   projectId: string;
 }
@@ -23,7 +24,8 @@ interface ProjectViewProps {
 const ProjectView = ({ projectId }: ProjectViewProps) => {
   const [activeFragment, setActiveFragment] = useState<Fragment | null>(null);
   const [tabState, setTabState] = useState<"preview" | "code">("preview");
-
+  const { has } = useAuth();
+  const hasProAccess = has?.({ plan: "pro_user" });
   return (
     <div className="h-screen">
       <ResizablePanelGroup direction="horizontal">
@@ -62,9 +64,11 @@ const ProjectView = ({ projectId }: ProjectViewProps) => {
               </TabsList>
               <div className="ml-auto flex items-center gap-x-2">
                 <Button asChild size="sm" variant="default">
-                  <Link href="/pricing">
-                    <CrownIcon /> Upgrade
-                  </Link>
+                  {!hasProAccess && (
+                    <Link href="/pricing">
+                      <CrownIcon /> Upgrade
+                    </Link>
+                  )}
                 </Button>
                 <UserControl showName={false} />
               </div>

--- a/src/modules/usage/server/procedures.ts
+++ b/src/modules/usage/server/procedures.ts
@@ -1,0 +1,13 @@
+import { getUsageStatus } from "@/lib/usage";
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+
+export const usageRouter = createTRPCRouter({
+  status: protectedProcedure.query(async () => {
+    try {
+      const result = await getUsageStatus();
+      return result;
+    } catch {
+      return null;
+    }
+  }),
+});

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,9 +1,11 @@
 import { projectsRouter } from "@/modules/projects/server/procedures";
 import { createTRPCRouter } from "../init";
 import { messagesRouter } from "@/modules/messages/server/procedures";
+import { usageRouter } from "@/modules/usage/server/procedures";
 export const appRouter = createTRPCRouter({
   messages: messagesRouter,
   projects: projectsRouter,
+  usage: usageRouter,
 });
 // export type definition of API
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
This commit introduces a usage-based billing system with a free tier and a pro plan, along with a new pricing page for users to upgrade.

Key changes:

- Implemented a credit system to track API usage for free and pro users.
- Logic to consume credits when users create projects or send messages.
- A new `/pricing` page with Clerk\'s `PricingTable` to display subscription options.
- The UI now shows remaining credits and time until reset.
- Users are redirected to the pricing page when they run out of credits.
- The "Upgrade" button is now conditionally displayed based on the user\'s plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Theme-aware Pricing page.
  * Usage/credit system with monthly allowance, status display, and countdown.
  * Credit checks gate project/message creation; redirects to Pricing when out of credits.
  * Upgrade prompts shown to non‑Pro users; Pricing route is public.
* UI
  * Navbar updates styling on scroll.
* Chores
  * Added rate limiting dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->